### PR TITLE
Fix typo in polyfit_converg_deg comment

### DIFF
--- a/utils/polyfit_converg_deg.m
+++ b/utils/polyfit_converg_deg.m
@@ -1,5 +1,5 @@
 function [NIR_deg, NIR_p, G_deg, G_p] = polyfit_converg_deg(mean_NIR_cycle, mean_G_cycle, stop_thresh)
-% Get degree that polyfit converges, and corresponding coeffici3nts
+% Get degree that polyfit converges, and corresponding coefficients
 if nargin<3
     stop_thresh = 0.99;
 end


### PR DESCRIPTION
## Summary
- fix typo in `polyfit_converg_deg` output description

## Testing
- `octave --eval "polyfit_converg_deg([0 0],[0 0])"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892a9c48118832bb2b44eb6ad0c7358