### PR TITLE
Fix trough mask initialization in motion artifact detection

### DIFF
--- a/utils/detect_motion_artifacts.m
+++ b/utils/detect_motion_artifacts.m
@@ -53,7 +53,7 @@ function [anomaly_idx, env_diff, upper_env, lower_env, good_peaks, good_troughs]
 
     % Filter peaks and troughs by removing any that fall within the expanded anomaly indices
     pk_mask = true(size(pk_locs));
-    tr_mask = true(size(pk_locs));
+    tr_mask = true(size(tr_locs));
     for i=1:length(pk_locs)
         if ismember(pk_locs(i), anomaly_idx)
             pk_mask(max(i-2,1):min(i+2,length(pk_locs))) = false;


### PR DESCRIPTION
## Summary
- Initialize trough mask based on trough locations so it matches the trough array.

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y octave` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892a9c38024832badb37d8dd1bbce03