### PR TITLE
Refactor triplet extraction utilities

### DIFF
--- a/utils/get_trip_norm_cycles.m
+++ b/utils/get_trip_norm_cycles.m
@@ -1,21 +1,33 @@
-function all_cycles = get_trip_norm_cycles(ppg, triplets, cycle_len)
-n_cycle = size(triplets,1);
-all_cycles = zeros(n_cycle, cycle_len);
-for i_cyc = 1:n_cycle
-    cyc = ppg(triplets(i_cyc,1):triplets(i_cyc,2));
-    cyc = interp_to_length(cyc, cycle_len);
-    cyc_debase = cyc - linspace(cyc(1), cyc(end), cycle_len);
-    all_cycles(i_cyc, :) = cyc_debase/max(cyc_debase);
-end
+%GET_TRIP_NORM_CYCLES Extract normalized cycles from a PPG signal.
+%
+%   cycles = GET_TRIP_NORM_CYCLES(ppg, triplets, cycle_len) returns a matrix
+%   where each row is a single pulse cycle extracted from the vector ppg.
+%   The cycles are defined by the onset/offset indices in triplets and are
+%   interpolated to cycle_len samples with baseline removal and amplitude
+%   normalization.
+%
+%   Inputs
+%       ppg       - Vector containing the PPG signal.
+%       triplets  - Nx3 array where each row is [onset, offset, peak].
+%       cycle_len - Number of samples to interpolate each cycle to.
+%
+%   Output
+%       cycles    - Matrix of size N-by-cycle_len containing normalized cycles.
+
+function cycles = get_trip_norm_cycles(ppg, triplets, cycle_len)
+
+    n_cycles = size(triplets, 1);
+    cycles = zeros(n_cycles, cycle_len);
+
+    for i = 1:n_cycles
+        % Extract the cycle and interpolate to the desired length
+        cyc = ppg(triplets(i, 1):triplets(i, 2));
+        cyc = interp_to_length(cyc, cycle_len);
+
+        % Remove linear trend and normalise by maximum amplitude
+        baseline = linspace(cyc(1), cyc(end), cycle_len);
+        cyc = cyc - baseline;
+        cycles(i, :) = cyc / max(cyc);
+    end
 end
 
-% figure();
-% subplot(2,1,1);
-% h_nir_cyc = plot(all_NIR_cycles'); hold on;
-% h_nir_cyc(1).Color(4) = 0.3;
-% plot(mean(all_NIR_cycles, 1), 'r-', 'LineWidth', 2);
-% 
-% subplot(2,1,2)
-% h_g_cyc = plot(all_G_cycles'); hold on;
-% h_g_cyc(1).Color(4) = 0.3;
-% plot(mean(all_G_cycles, 1), 'r', 'LineWidth', 2);

--- a/utils/peak_onset_tripletize.m
+++ b/utils/peak_onset_tripletize.m
@@ -1,15 +1,22 @@
-% Get triplets given peaks, onsets, and cycle_len
-function triplets = peak_onset_tripletize(peaks, onsets, cycle_len, thresh_multiplier, peak_ratio_denoise)
-% Matches peak between each onset pair.
-%   Inputs:
-%     onsets     - vector of onset indices (must be sorted)
-%     peaks      - vector of peak indices (must be sorted)
-%     cycle_len  - minimum duration (in samples) between onsets 
-%     thresh_multiplier - length of each cycle
+% Get triplets given peaks, onsets, and cycle length.
 %
-%   Output:
-%     triplets   - Nx3 matrix, each row is [onset_i, onset_i+1, peak]
-    if nargin < 4
+% Matches the dominant peak between each pair of consecutive onsets and
+% optionally removes outliers based on the relative peak position.
+%
+% Inputs
+%   peaks  - Sorted vector of peak indices.
+%   onsets - Sorted vector of onset indices.
+%   cycle_len - Expected duration (in samples) of each cycle.
+%   thresh_multiplier - Allowed relative deviation from cycle_len. Default: 0.25
+%   peak_ratio_denoise - Enable additional ratio based denoising. Default: false
+%
+% Output
+%   triplets - Nx3 array where each row is [onset_i, onset_{i+1}, peak_i].
+
+function triplets = peak_onset_tripletize(peaks, onsets, cycle_len, ...
+    thresh_multiplier, peak_ratio_denoise)
+
+    if nargin < 4 || isempty(thresh_multiplier)
         thresh_multiplier = 0.25;
     end
 
@@ -17,39 +24,48 @@ function triplets = peak_onset_tripletize(peaks, onsets, cycle_len, thresh_multi
         peak_ratio_denoise = false;
     end
 
-    triplets = [];
-    peak_ratios = [];
+    n_onsets = numel(onsets);
+    % Preallocate maximum possible size to avoid dynamic resizing
+    triplets = zeros(max(n_onsets - 1, 0), 3);
+    peak_ratios = zeros(1, max(n_onsets - 1, 0));
+    t_idx = 0;
 
-    n_onsets = length(onsets);
     for i = 1:n_onsets - 1
         start_idx = onsets(i);
-        end_idx = onsets(i+1);
-        cycle_idx = onsets(i+1) - onsets(i);
+        end_idx   = onsets(i + 1);
+        cycle_idx = end_idx - start_idx;
 
-        if abs(cycle_idx - cycle_len) > thresh_multiplier*cycle_len
-            continue;  % skip too short cycles
+        % Skip cycles that deviate too much from expected length
+        if abs(cycle_idx - cycle_len) > thresh_multiplier * cycle_len
+            continue;
         end
 
         % Find peaks in this interval
         in_range = peaks(peaks > start_idx & peaks < end_idx);
 
-        if isempty(in_range) | length(in_range) > 1
-            continue;  % no peak found between this pair of onsets
+        % Require exactly one peak per cycle
+        if isempty(in_range) || numel(in_range) > 1
+            continue;
         end
-        
+
+        t_idx = t_idx + 1;
+        triplets(t_idx, :) = [start_idx, end_idx, in_range];
+
         if peak_ratio_denoise
-            peak_ratios(end+1) = (in_range - start_idx)/cycle_idx;
+            peak_ratios(t_idx) = (in_range - start_idx) / cycle_idx;
         end
-        % Append to triplet list
-        triplets(end+1, :) = [start_idx, end_idx, in_range];
     end
 
-    if peak_ratio_denoise
+    % Remove unused preallocated rows
+    triplets = triplets(1:t_idx, :);
+    peak_ratios = peak_ratios(1:t_idx);
+
+    if peak_ratio_denoise && ~isempty(peak_ratios)
         prct25 = prctile(peak_ratios, 25);
         prct75 = prctile(peak_ratios, 75);
         iqr = prct75 - prct25;
-        peak_ratio_mask = find(peak_ratios > prct25-iqr*1.75 & ...
-            peak_ratios < prct75+iqr*1.75);
-        triplets = triplets(peak_ratio_mask, :);
+        mask = peak_ratios > prct25 - iqr * 1.75 & ...
+               peak_ratios < prct75 + iqr * 1.75;
+        triplets = triplets(mask, :);
     end
 end


### PR DESCRIPTION
## Summary
- clean up `peak_onset_tripletize` with documentation, preallocation, and clearer optional denoising
- rewrite `get_trip_norm_cycles` with concise baseline removal and cycle normalization

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, cannot install octave)*

------
https://chatgpt.com/codex/tasks/task_e_6892a848fca4832bafb8d017a2c638f7